### PR TITLE
ensure feathers() args are numeric

### DIFF
--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -13,13 +13,14 @@ function feathers(normalF, easyF, bucket, n)
     if n == nil then; n = 0; end
     if n > 10 then; return false; end -- detect 10th step when trying to resolve and abort
     n = n + 1
+    bucket = tonumber(bucket)
 
     local minfeathers = 0
 
     if easy(n) then
-        minfeathers = easyF
+        minfeathers = tonumber(easyF)
     elseif normal(n) then
-        minfeathers = normalF
+        minfeathers = tonumber(normalF)
     elseif hard(n) then
         minfeathers = 0
     end


### PR DESCRIPTION
When called in an accessrule the arguments are passed as strings, which causes it to break on rules such as e.g. `$feathers|3|10|10`, since Lua strings are compared alphabetically and "10" < "3" returns true.

See this bug report: https://discord.com/channels/731205301247803413/1224389725922787389/1257428151877767209

and this line from the [poptracker documentation](https://github.com/black-sliver/PopTracker/blob/2f1d13090402d8a6c616f0269899c9e9ff75f4a5/doc/PACKS.md?plain=1#L439C1-L439C90): 
For `$` rules, arguments can be supplied with `|`. `$test|a|b` will call `test("a","b")`.