### PR TITLE
BUGFIX: Rod shop logic fixes

### DIFF
--- a/items/items.json
+++ b/items/items.json
@@ -33,7 +33,7 @@
             },
             {
                 "img": "images/icons/icon_goldenRod.png",
-                "codes": "goldrod",
+                "codes": "rod,goldrod",
                 "inherit_codes": false
             }
         ]


### PR DESCRIPTION
`goldrod` doesn't provide the `rod` itemcode which causes some errors in shop-check logic
https://github.com/chandler05/shorthike-archipelago-poptracker/blob/68ae3afcdfa167b62a046fd6d2f7cafa5cd9f9b9/scripts/logic/logic.lua#L46

https://github.com/chandler05/shorthike-archipelago-poptracker/blob/68ae3afcdfa167b62a046fd6d2f7cafa5cd9f9b9/scripts/logic/logic.lua#L50